### PR TITLE
Remove duplicate code. Update documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,14 +146,17 @@ render-carafe-source -h
   configuration: Source files are loaded from the current directory by default.
                  Source file paths may be customized in your package.json.
   options:
-    -p  <argument> Overrides the default localhost port (8080)
+    -p  <argument> Overrides the default localhost port (default is 8080)
+    -s  Send the compiled Bundle to Carafe.fmp12 if it is open on the host system (default is false)
+    -u  <argument> URL for send (default is fmp://$/Carafe?script=Send%20Carafe%20Bundle&param={sendConfig})
+        Note: {sendConfig} will be expanded into a JSON object with path string and forceSend bool properties at runtime
+    -f  Force the send to overwrite without prompting the user (default is false)
     -h  Shows this help text
-
 ```
 
 Server defaults to `localhost:8080`
 
-### Compile Source Files Into A Bundle And Optional Push to FileMaker
+### Compile Source Files Into A Bundle And Optional Send to FileMaker
 
 Compiles source files and outputs a Bundle to the specified path
 
@@ -168,13 +171,12 @@ compile-carafe-bundle -h
            Optionally sends Bundle to Carafe.fmp12 if it is open on the host system.
 
   configuration: Source files are loaded from the current directory by default.
-                 Source file paths and push URL may be customized in your package.json.
+                 Source file paths and send URL may be customized in your package.json.
   options:
-    -b  <argument> Bundle path (dist/Carafe-Bundle-{name}-{version}.json)
-    -p  Push the compiled Bundle to Carafe.fmp12 if it is open on the host system (default is false)
-    -f  Force the push to overwrite without prompting the user (default is false)
-    -u  <argument> URL for push (fmp://$/Carafe?script=Push%20Carafe%20Bundle&param={pushConfig})
-        Note: {pushConfig} will be expanded into a JSON object with path string and forcePush bool properties at runtime
+    -b  <argument> Bundle path (default is dist/Carafe-Bundle-{name}-{version}.json)
+    -s  Send the compiled Bundle to Carafe.fmp12 if it is open on the host system (default is false)
+    -u  <argument> URL for send (default is fmp://$/Carafe?script=Send%20Carafe%20Bundle&param={sendConfig})
+        Note: {sendConfig} will be expanded into a JSON object with path string and forceSend bool properties at runtime
+    -f  Force the send to overwrite without prompting the user (default is false)
     -h  Shows this help text
-
 ```

--- a/bin/compile-carafe-bundle.js
+++ b/bin/compile-carafe-bundle.js
@@ -13,16 +13,16 @@ const open = require('open');
 const args = minimist(process.argv.slice(2), {
     default: {
         b: 'dist/Carafe_{name}_v{version}.json',
+        s: false,
         u: null,
-        p: false,
         f: false,
         h: false
     },
     alias: {
         b: 'bundlePath',
-        u: 'urlPush',
-        p: 'push',
-        f: 'forcePush',
+        s: 'send',
+        u: 'urlSend',
+        f: 'forceSend',
         h: 'help'
     }
 });
@@ -40,13 +40,13 @@ if (args.help) {
     console.log('           Optionally sends Bundle to ' + chalk.blue.bold('Carafe.fmp12') + ' if it is open on the host system.');
     console.log('');
     console.log(chalk.yellow('  configuration:') + ' Source files are loaded from the current directory by default.');
-    console.log('                 Source file paths and push URL may be customized in your ' + chalk.blue.bold('package.json') + '.');
+    console.log('                 Source file paths and send URL may be customized in your ' + chalk.blue.bold('package.json') + '.');
     console.log(chalk.yellow('  options:'));
-    console.log('    -b  ' + chalk.blue.bold('<argument>') + ' Bundle path (' + chalk.blue('dist/Carafe-Bundle-{name}-{version}.json') + ')');
-    console.log('    -p  Push the compiled Bundle to Carafe.fmp12 if it is open on the host system (default is ' + chalk.blue('false') + ')');
-    console.log('    -f  Force the push to overwrite without prompting the user (default is ' + chalk.blue('false') + ')');
-    console.log('    -u  ' + chalk.blue.bold('<argument>') + ' URL for push (' + chalk.blue('fmp://$/Carafe?script=Push%20Carafe%20Bundle&param={pushConfig}') + ')');
-    console.log('        Note: ' + chalk.blue.bold('{pushConfig}') + ' will be expanded into a JSON object with ' + chalk.blue.bold('path') + ' string and ' + chalk.blue.bold('forcePush') + ' bool properties at runtime');
+    console.log('    -b  ' + chalk.blue.bold('<argument>') + ' Bundle path (default is ' + chalk.blue('dist/Carafe-Bundle-{name}-{version}.json') + ')');
+    console.log('    -s  Send the compiled Bundle to Carafe.fmp12 if it is open on the host system (default is ' + chalk.blue('false') + ')');
+    console.log('    -u  ' + chalk.blue.bold('<argument>') + ' URL for send (default is ' + chalk.blue('fmp://$/Carafe?script=Send%20Carafe%20Bundle&param={sendConfig}') + ')');
+    console.log('        Note: ' + chalk.blue.bold('{sendConfig}') + ' will be expanded into a JSON object with ' + chalk.blue.bold('path') + ' string and ' + chalk.blue.bold('forceSend') + ' bool properties at runtime');
+    console.log('    -f  Force the send to overwrite without prompting the user (default is ' + chalk.blue('false') + ')');
     console.log('    -h  Shows this help text');
     console.log('');
     process.exit(1);
@@ -79,16 +79,16 @@ fs.writeFileSync(outputFilename, bundle);
 
 console.log('Bundle output to ' + path.resolve(outputFilename));
 
-const pushConfig = JSON.stringify({
+const sendConfig = JSON.stringify({
     path: path.resolve(outputFilename),
-    forcePush: args.forcePush
+    forceSend: args.forceSend
 });
 
 // url argument takes precedent over config. See src/bundle-config.js for default config value
-let fmpPushUrl = args.urlPush ? args.urlPush : bundleConfig.pushFmpUrl;
-const url = fmpPushUrl.replace(/{pushConfig}/g, encodeURIComponent(pushConfig));
+let fmpSendUrl = args.urlSend ? args.urlSend : bundleConfig.sendFmpUrl;
+const url = fmpSendUrl.replace(/{sendConfig}/g, encodeURIComponent(sendConfig));
 
-if (args.push) {
+if (args.send) {
     console.log('Opening ' + url);
     (async () => {
         try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@carafe-fm/bundler",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carafe-fm/bundler",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Bundler for carafe files",
   "bin": {
     "render-carafe-bundle": "bin/render-carafe-bundle.js",

--- a/src/bundle-config.js
+++ b/src/bundle-config.js
@@ -8,7 +8,7 @@ class BundleConfig
         this.dataFilename = 'data.json';
         this.metaFilename = 'meta.json';
         this.previewFilename = 'preview.jpg';
-        this.pushFmpUrl = 'fmp://$/Carafe?script=Push%20Carafe%20Bundle&param={pushConfig}';
+        this.sendFmpUrl = 'fmp://$/Carafe?script=Send%20Carafe%20Bundle&param={sendConfig}';
         this.watchedFiles = [];
 
         if (! fs.existsSync(workDir + '/' + 'package.json')) {
@@ -41,8 +41,8 @@ class BundleConfig
             this.previewFilename = packageConfig.carafe.previewFilename;
         }
 
-        if (packageConfig.carafe.pushFmpUrl) {
-            this.pushFmpUrl = packageConfig.carafe.pushFmpUrl;
+        if (packageConfig.carafe.sendFmpUrl) {
+            this.sendFmpUrl = packageConfig.carafe.sendFmpUrl;
         }
 
         if (packageConfig.carafe.watchedFiles) {


### PR DESCRIPTION
The `send-server.js` was a copy/paste of the compile bin, so I deleted it, and hooked the source renderer directly into the compile bin with a Promise function instead.

I also updated the CLI documentation and the README. I'm not thrilled about the duplicate CLI documentation, but -s, -u, -f are all passthrough args, so I figured it's better to show them in the source render bin too, and I didn't want to go crazy abstracting that yet.